### PR TITLE
fix(#2): allow empty input and select-on-focus for role limit fields

### DIFF
--- a/src/components/settings/PartySettings.tsx
+++ b/src/components/settings/PartySettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type FocusEvent } from 'react'
 import { AGENTS_BY_ROLE, ROLES } from '../../data/agents'
 import type { AgentConstraint, RoleId } from '../../logic/types'
 import { usePlayerStore } from '../../stores/playerStore'
@@ -6,6 +6,73 @@ import { useShallow } from 'zustand/react/shallow'
 import { ChevronIcon } from '../icons/ChevronIcon'
 import { useTranslation } from '../../i18n/useTranslation'
 import type { TranslationKey } from '../../i18n/locales/ja'
+
+/**
+ * ロール人数制限の数値入力。
+ * Issue #2: 空文字中間状態を許容し、フォーカス時に全選択することで
+ * 「既存値を消してから任意の値を入力する」という自然な操作を成立させる。
+ *
+ * - focused 中は draft 文字列を表示（空文字も可）
+ * - onChange で有効な整数なら props の [min, max] にクランプして即 commit
+ * - blur で draft を store の値に戻し、入力途中の不整合表示を消す
+ */
+interface NumberInputProps {
+  readonly value: number
+  readonly min: number
+  readonly max: number
+  readonly onCommit: (value: number) => void
+  readonly id: string
+  readonly 'data-testid': string
+  readonly className?: string
+}
+
+function NumberInput({
+  value,
+  min,
+  max,
+  onCommit,
+  id,
+  'data-testid': testId,
+  className,
+}: NumberInputProps) {
+  const [draft, setDraft] = useState(String(value))
+  const [focused, setFocused] = useState(false)
+
+  const displayValue = focused ? draft : String(value)
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    setDraft(String(value))
+    setFocused(true)
+    e.target.select()
+  }
+
+  return (
+    <input
+      type="number"
+      id={id}
+      data-testid={testId}
+      value={displayValue}
+      min={min}
+      max={max}
+      step="1"
+      onFocus={handleFocus}
+      onBlur={() => {
+        setDraft(String(value))
+        setFocused(false)
+      }}
+      onChange={(e) => {
+        setDraft(e.target.value)
+        if (e.target.value === '') return
+        // Number() は "1e10"・"0x10" 等も受け付けるが、isInteger で弾く。
+        // 科学表記や小数は UI 仕様として非対応。
+        const n = Number(e.target.value)
+        if (!Number.isInteger(n)) return
+        onCommit(Math.max(min, Math.min(max, n)))
+      }}
+      className={className}
+    />
+  )
+}
 
 // 順序: 除外（ネガティブ）→ 対象（ニュートラル）→ 必須（ポジティブ）
 // label はキー。コンポーネント内で t() で翻訳する。
@@ -151,23 +218,13 @@ function PartySettings({ playerCount }: Props) {
                       >
                         {t('party.min')}
                       </label>
-                      <input
-                        type="number"
+                      <NumberInput
                         id={`role-limit-${role.id}-min`}
                         data-testid={`role-limit-${role.id}-min`}
                         value={limit.min}
                         min={0}
                         max={limit.max}
-                        step="1"
-                        onChange={(e) => {
-                          const v = parseInt(e.target.value, 10)
-                          if (Number.isNaN(v)) return
-                          setRoleLimit(
-                            role.id,
-                            Math.min(v, limit.max),
-                            limit.max,
-                          )
-                        }}
+                        onCommit={(v) => setRoleLimit(role.id, v, limit.max)}
                         className="w-14 border border-border rounded px-2 py-2 text-center bg-bg-elevated text-text-primary focus:outline-none focus:border-accent"
                       />
                       <label
@@ -176,23 +233,13 @@ function PartySettings({ playerCount }: Props) {
                       >
                         {t('party.max')}
                       </label>
-                      <input
-                        type="number"
+                      <NumberInput
                         id={`role-limit-${role.id}-max`}
                         data-testid={`role-limit-${role.id}-max`}
                         value={Math.min(limit.max, playerCount)}
                         min={limit.min}
                         max={playerCount}
-                        step="1"
-                        onChange={(e) => {
-                          const v = parseInt(e.target.value, 10)
-                          if (Number.isNaN(v)) return
-                          setRoleLimit(
-                            role.id,
-                            limit.min,
-                            Math.min(v, playerCount),
-                          )
-                        }}
+                        onCommit={(v) => setRoleLimit(role.id, limit.min, v)}
                         className="w-14 border border-border rounded px-2 py-2 text-center bg-bg-elevated text-text-primary focus:outline-none focus:border-accent"
                       />
                     </div>

--- a/src/components/settings/PartySettings.tsx
+++ b/src/components/settings/PartySettings.tsx
@@ -63,8 +63,9 @@ function NumberInput({
       onChange={(e) => {
         setDraft(e.target.value)
         if (e.target.value === '') return
-        // Number() は "1e10"・"0x10" 等も受け付けるが、isInteger で弾く。
-        // 科学表記や小数は UI 仕様として非対応。
+        // "1.5"・"abc"・"Infinity" は isInteger=false で弾かれる。
+        // "1e2"=100・"0xff"=255 のような整数値に解釈される表記は通過するが、
+        // 直後の Math.max/min クランプで store へは常に [min, max] の整数のみ渡る。
         const n = Number(e.target.value)
         if (!Number.isInteger(n)) return
         onCommit(Math.max(min, Math.min(max, n)))

--- a/tests/e2e/roleLimitInput.spec.ts
+++ b/tests/e2e/roleLimitInput.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Issue #2: ロール人数制限 min/max input の UX 改善。
+ *  - Playwright fill() はクリア→セット相当で従来どおり動作することを確認
+ *  - 手動の「全削除→任意値入力」がユーザー操作として成立すること
+ *  - フォーカス時に既存値が全選択され、直接上書きしやすいこと
+ *  - 空のまま blur したら前回有効値に戻ること（store 側には不正値を書かない）
+ *  - props の min/max 範囲外の入力は UI 側でクランプされること
+ */
+test.describe('Issue #2: ロール人数制限 input の UX 改善', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    // playerCount=3 にセットする。これにより roleLimits[*].max の初期値は 3（= playerCount）、
+    // min の初期値は 0 になる。以降のテストはこの前提で assert している。
+    await page.getByRole('button', { name: 'プレイヤーを追加' }).click()
+    await page.getByRole('button', { name: 'プレイヤーを追加' }).click()
+    await expect(page.getByTestId('player-card')).toHaveCount(3)
+    await page
+      .getByRole('button', { name: 'ロール人数制限', exact: true })
+      .click()
+  })
+
+  // E2E-PARTY-INPUT-001: 既存値を全消去してから任意値を入力できる
+  test('E2E-PARTY-INPUT-001: 最大値を Ctrl+A→Delete で消してから 1 を入力して確定できる', async ({
+    page,
+  }) => {
+    const maxInput = page.getByTestId('role-limit-duelist-max')
+    await expect(maxInput).toHaveValue('3')
+
+    await maxInput.focus()
+    await maxInput.press('ControlOrMeta+a')
+    await maxInput.press('Delete')
+    await maxInput.pressSequentially('1')
+    await maxInput.blur()
+
+    await expect(maxInput).toHaveValue('1')
+  })
+
+  // E2E-PARTY-INPUT-002: 最小値でも同様に全消去→任意値入力できる
+  test('E2E-PARTY-INPUT-002: 最小値を Ctrl+A→Delete で消してから 2 を入力して確定できる', async ({
+    page,
+  }) => {
+    const minInput = page.getByTestId('role-limit-duelist-min')
+    await expect(minInput).toHaveValue('0')
+
+    await minInput.focus()
+    await minInput.press('ControlOrMeta+a')
+    await minInput.press('Delete')
+    await minInput.pressSequentially('2')
+    await minInput.blur()
+
+    await expect(minInput).toHaveValue('2')
+  })
+
+  // E2E-PARTY-INPUT-003: 空文字のまま blur すると前回の有効値に戻る（max）
+  test('E2E-PARTY-INPUT-003a: 最大値を全削除したまま blur すると前回有効値が復元される', async ({
+    page,
+  }) => {
+    const maxInput = page.getByTestId('role-limit-duelist-max')
+    await expect(maxInput).toHaveValue('3')
+
+    await maxInput.focus()
+    await maxInput.press('ControlOrMeta+a')
+    await maxInput.press('Delete')
+    await expect(maxInput).toHaveValue('')
+
+    await maxInput.blur()
+    await expect(maxInput).toHaveValue('3')
+  })
+
+  // E2E-PARTY-INPUT-003b: 空文字のまま blur すると前回の有効値に戻る（min）
+  // min と max は NumberInput の独立インスタンスであり、state 共有がないことも併せて担保する。
+  test('E2E-PARTY-INPUT-003b: 最小値を全削除したまま blur すると前回有効値が復元される', async ({
+    page,
+  }) => {
+    const minInput = page.getByTestId('role-limit-duelist-min')
+    // 一旦 2 に変更してから空にして blur → 2 に戻ることで「前回有効値の保持」を検証
+    await minInput.fill('2')
+    await expect(minInput).toHaveValue('2')
+
+    await minInput.focus()
+    await minInput.press('ControlOrMeta+a')
+    await minInput.press('Delete')
+    await expect(minInput).toHaveValue('')
+
+    await minInput.blur()
+    await expect(minInput).toHaveValue('2')
+  })
+
+  // E2E-PARTY-INPUT-004: フォーカス直後にキー入力すると全選択分が置き換えられる
+  // onFocus での select() により「既存値が全選択状態」になる効果を、
+  // 「全選択されていないと生じない動作（1 文字入力で値全体が置換される）」で検証する。
+  // selectionStart/End は <input type="number"> では Chromium が null を返すため直接検証できない。
+  test('E2E-PARTY-INPUT-004: フォーカス直後にキー入力すると全選択分が置き換えられる', async ({
+    page,
+  }) => {
+    const maxInput = page.getByTestId('role-limit-duelist-max')
+    await expect(maxInput).toHaveValue('3')
+
+    await maxInput.focus()
+    await maxInput.pressSequentially('1')
+    await maxInput.blur()
+
+    // select() が効かなければ "31" となり clamp で "3" に戻るはず。
+    // "1" で確定することが select() の効果の間接証拠になる。
+    await expect(maxInput).toHaveValue('1')
+  })
+
+  // E2E-PARTY-INPUT-005: max に playerCount を超える値を入力すると UI 側で playerCount にクランプされる
+  test('E2E-PARTY-INPUT-005: 最大値に playerCount(3) 超え 9 を fill すると 3 にクランプされる', async ({
+    page,
+  }) => {
+    const maxInput = page.getByTestId('role-limit-duelist-max')
+    await maxInput.fill('9')
+    await maxInput.blur()
+
+    await expect(maxInput).toHaveValue('3')
+  })
+
+  // E2E-PARTY-INPUT-006: min に現在の max を超える値を入力すると max 値にクランプされる
+  test('E2E-PARTY-INPUT-006: max=1 設定後に min へ 4 を fill すると 1 にクランプされる', async ({
+    page,
+  }) => {
+    const maxInput = page.getByTestId('role-limit-duelist-max')
+    const minInput = page.getByTestId('role-limit-duelist-min')
+
+    // 先に max を 1 に下げる
+    await maxInput.fill('1')
+    await maxInput.blur()
+    await expect(maxInput).toHaveValue('1')
+
+    // min に max を超える値 4 を入力 → NumberInput props max=limit.max=1 でクランプ
+    await minInput.fill('4')
+    await minInput.blur()
+    await expect(minInput).toHaveValue('1')
+  })
+
+  // E2E-PARTY-INPUT-007: min=0 の最小境界値を明示的に設定できる
+  test('E2E-PARTY-INPUT-007: min に 0 を入力して blur すると 0 を維持する', async ({
+    page,
+  }) => {
+    const minInput = page.getByTestId('role-limit-duelist-min')
+
+    // 一旦 2 に変更してから 0 に戻す
+    await minInput.fill('2')
+    await minInput.blur()
+    await expect(minInput).toHaveValue('2')
+
+    await minInput.fill('0')
+    await minInput.blur()
+    await expect(minInput).toHaveValue('0')
+  })
+})


### PR DESCRIPTION
## Summary

- Issue #2 の「ロール人数制限の最大インプットボックスが入力しにくい」に対応
- `<input type="number">` を controlled なまま draft 文字列 + focused フラグ付きの `NumberInput` サブコンポーネントに置き換え、空文字中間状態を許容
- `onFocus` で `e.target.select()` を呼び、既存値をフォーカス直後に上書き可能に
- 入力値検証を `parseInt` から `Number` + `Number.isInteger` に変更（`1.5` / `abc` / `Infinity` を弾く）、クランプ責任を `NumberInput` 内に一本化

## Why

従来は onChange の `parseInt` NaN ガードで空文字を弾いていたため、React の controlled input が元値を即座に押し戻し、ユーザーは「BackSpace で消してから入力」が成立せず、先頭 `0` を挟む非直感的な手順を強いられていた。フォーカス直後の直接上書きもできなかった。

## Changes

- `src/components/settings/PartySettings.tsx`
  - `NumberInput` サブコンポーネント新設（draft state + focused フラグ + onFocus select + blur 時復元）
  - props を `readonly` で固定、クランプは `Math.max(min, Math.min(max, n))` で一本化
  - 呼び出し側の冗長な `Math.min` を削除
- `tests/e2e/roleLimitInput.spec.ts`（新規）
  - 8 ケース: clear→type（min/max）、フォーカス全選択、空文字 blur 復元（min/max）、max > playerCount クランプ、min > max クロスクランプ、min=0 境界

## Related

- Closes #2

## Test plan

- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` 全パス
- [x] `npm test` 150 件パス
- [x] `npx playwright test` 76 件パス（既存 68 + 新規 8）
- [x] `/full-review` で 5 エージェント並列レビュー後、妥当な指摘（H2 / M1 / M2 / M3 / M5 / M6 / M7 / H3）を反映。誤検知（H1: useEffect 同期は typing 中の clamp race で新バグを生むため却下）は却下理由と共に記録
- [x] `/security-scan` で 5 脆弱性カテゴリの静的スキャン + adversarial / defender 二者レビュー実施、Critical/High/Medium なし、L1（コメント不正確）は追コミット `fba09be` で対応済み
- [x] `/e2e-verify issue` で Issue #2 の 8 ユースケース全カバー確認（`docs/verify/issue-2-verify.md`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)